### PR TITLE
Improve comment readability when there are no changes

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -188,18 +188,24 @@ if [[ $COMMAND == 'plan' ]]; then
   if [[ $EXIT_CODE -eq 0 || $EXIT_CODE -eq 2 ]]; then
     CLEAN_PLAN=$(echo "$INPUT" | sed -r '/^(An execution plan has been generated and is shown below.|Terraform used the selected providers to generate the following execution|No changes. Infrastructure is up-to-date.|No changes. Your infrastructure matches the configuration.|Note: Objects have changed outside of Terraform)$/,$!d') # Strip refresh section
     CLEAN_PLAN=$(echo "$CLEAN_PLAN" | sed -r '/Plan: /q') # Ignore everything after plan summary
-    CLEAN_PLAN=${CLEAN_PLAN::65300} # GitHub has a 65535-char comment limit - truncate plan, leaving space for comment wrapper
-    CLEAN_PLAN=$(echo "$CLEAN_PLAN" | sed -r 's/^([[:blank:]]*)([-+~])/\2\1/g') # Move any diff characters to start of line
-    if [[ $COLOURISE == 'true' ]]; then
-      CLEAN_PLAN=$(echo "$CLEAN_PLAN" | sed -r 's/^~/!/g') # Replace ~ with ! to colourise the diff in GitHub comments
-    fi
-    PR_COMMENT="### Terraform \`plan\` Succeeded for Workspace: \`$WORKSPACE\` $comment
+
+    # Check if there are no changes by looking for specific patterns in the plan output
+    if [[ $CLEAN_PLAN =~ "No changes. Your infrastructure matches the configuration." ]]; then
+      PR_COMMENT="### ✓ Terraform \`plan\` Succeeded for Workspace: \`$WORKSPACE\` - No Changes Detected $comment"
+    else
+      CLEAN_PLAN=${CLEAN_PLAN::65300} # GitHub has a 65535-char comment limit - truncate plan, leaving space for comment wrapper
+      CLEAN_PLAN=$(echo "$CLEAN_PLAN" | sed -r 's/^([[:blank:]]*)([-+~])/\2\1/g') # Move any diff characters to start of line
+      if [[ $COLOURISE == 'true' ]]; then
+        CLEAN_PLAN=$(echo "$CLEAN_PLAN" | sed -r 's/^~/!/g') # Replace ~ with ! to colourise the diff in GitHub comments
+      fi
+      PR_COMMENT="### Terraform \`plan\` Succeeded for Workspace: \`$WORKSPACE\` $comment
 <details$DETAILS_STATE><summary>Show Output</summary>
 
 \`\`\`diff
 $CLEAN_PLAN
 \`\`\`
 </details>"
+    fi
   fi
 
   # Exit Code: 1


### PR DESCRIPTION
This change makes it easier to see if there are no changes to a Terraform project. It does not require to open the collapsed view.

This is how it looks like if there are changes or not:
<img width="1029" alt="image" src="https://github.com/user-attachments/assets/003ffcb9-ac8d-4177-a420-a85c74590c1e" />
