### PR TITLE
chore: support infinite plans

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,8 +9,13 @@ inputs:
     description: 'The type of comment. Options: [fmt, init, plan]'
     required: true
   commenter_input:
-    description: 'The comment to post from a previous step output'
-    required: true
+    description: 'the comment to post from a previous step output'
+    required: false
+    default: ''
+  commenter_input_file:
+    description: 'the comment to post from a previous step output passed as file name (see README.md for more information)'
+    required: false
+    default: ''
   commenter_exitcode:
     description: 'The exit code from a previous step output'
     required: true
@@ -26,3 +31,4 @@ runs:
     - ${{ inputs.commenter_input }}
     - ${{ inputs.commenter_exitcode }}
     - ${{ inputs.commenter_comment }}
+    - ${{ inputs.commenter_input_file }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,7 +24,21 @@ if [[ ! "$1" =~ ^(fmt|init|plan|validate)$ ]]; then
   exit 1
 fi
 
+if [ "$2" ]; then
+  input_raw="$2"
+fi
+
 comment="$4"
+file="$5"
+
+if [ "$file" ]; then
+  input_raw="$(</github/workspace/$file)"
+fi
+
+if [ -z "$input_raw" ]; then
+  echo "No input specified" >&2
+  exit 1
+fi
 
 ##################
 # Shared Variables
@@ -32,7 +46,7 @@ comment="$4"
 # Arg 1 is command
 COMMAND=$1
 # Arg 2 is input. We strip ANSI colours.
-INPUT=$(echo "$2" | sed 's/\x1b\[[0-9;]*m//g')
+INPUT=$(echo "$input_raw" | sed 's/\x1b\[[0-9;]*m//g')
 # Arg 3 is the Terraform CLI exit code
 EXIT_CODE=$3
 


### PR DESCRIPTION
Sometimes plans become so large that they do not fit into the command line as args. To stay backwards compatible lets us add support to pass the input using a file.

Tested in a repository with a large plan output.

## References:

- https://docs.github.com/en/actions/sharing-automations/creating-actions/creating-a-docker-container-action#accessing-files-created-by-a-container-action